### PR TITLE
修复 setuptools_scm.dump_version 调用错误

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -93,7 +93,7 @@ jobs:
 
           # Update __version__.py file with setuptools_scm
           python -c "from setuptools_scm import get_version; print(f'Version from setuptools_scm: {get_version()}')"
-          python -c "import setuptools_scm; setuptools_scm.dump_version('src/py_dem_bones', '$NEW_VERSION')"
+          python -c "import setuptools_scm; setuptools_scm.dump_version(version='$NEW_VERSION', write_to='src/py_dem_bones/__version__.py')"
 
           # Check if version files were updated
           echo "Checking version files..."


### PR DESCRIPTION
## Problem

In the `.github/workflows/bumpversion.yml` file, the `setuptools_scm.dump_version` function call doesn't match the requirements of the latest API version, resulting in the following error:

```
TypeError: dump_version() missing 1 required positional argument: 'write_to'
```

## Solution

Updated the `dump_version` function call to use named parameters instead of positional parameters:

```python
setuptools_scm.dump_version(version='$NEW_VERSION', write_to='src/py_dem_bones/__version__.py')
```

This ensures that the function call complies with the latest API requirements, resolving the error in the version update process.