### PR TITLE
Fix version update process in CI

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -93,7 +93,17 @@ jobs:
 
           # Update __version__.py file with setuptools_scm
           python -c "from setuptools_scm import get_version; print(f'Version from setuptools_scm: {get_version()}')"
+
+          # Ensure setuptools is updated to a compatible version
+          python -m pip install --upgrade "setuptools>=61.0.0"
+
+          # Update version files using setuptools_scm
           python -c "import setuptools_scm; setuptools_scm.dump_version(root='.', version='$NEW_VERSION', write_to='src/py_dem_bones/__version__.py')"
+
+          # Update docs/conf.py manually since it's not being updated by setuptools_scm
+          echo "# Version information" > docs/conf.py
+          echo "version = '$NEW_VERSION'" >> docs/conf.py
+          echo "release = '$NEW_VERSION'" >> docs/conf.py
 
           # Check if version files were updated
           echo "Checking version files..."

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -93,7 +93,7 @@ jobs:
 
           # Update __version__.py file with setuptools_scm
           python -c "from setuptools_scm import get_version; print(f'Version from setuptools_scm: {get_version()}')"
-          python -c "import setuptools_scm; setuptools_scm.dump_version(version='$NEW_VERSION', write_to='src/py_dem_bones/__version__.py')"
+          python -c "import setuptools_scm; setuptools_scm.dump_version(root='.', version='$NEW_VERSION', write_to='src/py_dem_bones/__version__.py')"
 
           # Check if version files were updated
           echo "Checking version files..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "scikit-build-core>=0.5.0",
     "pybind11>=2.10.0",
     "numpy>=1.20.0",
-    "setuptools>=42.0.0",
+    "setuptools>=61.0.0",  # Required by setuptools_scm>=8.0.0
     "wheel>=0.36.0",
     "setuptools_scm>=8.0.0",
 ]
@@ -170,7 +170,7 @@ update_changelog_on_bump = true
 change_type_order = ["BREAKING CHANGE", "feat", "fix", "refactor", "perf", "ci", "build", "docs", "test", "chore"]
 version_files = [
     "pyproject.toml:fallback_version",
-    # __version__.py is now handled by setuptools_scm directly
+    # __version__.py is handled by setuptools_scm in the bumpversion workflow
     "docs/conf.py:version = "
 ]
 # Version bump rules


### PR DESCRIPTION
## Problem

The version update process in CI has several issues:

1. The `setuptools_scm.dump_version` function call is missing the required `root` parameter
2. The installed setuptools version (58.1.0) is incompatible with setuptools_scm 8.x, which requires setuptools>=61
3. The docs/conf.py file is not being properly updated during version bumps

## Solution

1. Added the required `root` parameter to the `setuptools_scm.dump_version` function call
2. Added an explicit upgrade of setuptools to a compatible version (>=61.0.0) in the CI workflow
3. Added explicit code to update docs/conf.py with the new version
4. Updated the build-system requirements in pyproject.toml to specify the correct setuptools version
5. Improved comments in the configuration files for better clarity

These changes should ensure that the version update process works correctly and consistently.