### PR TITLE
Fix multiple workflow triggers on version updates

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   bump-version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:') && !startsWith(github.event.head_commit.message, 'chore(release)')"
+    if: "!startsWith(github.event.head_commit.message, 'bump:') && !startsWith(github.event.head_commit.message, 'chore(release)') && !startsWith(github.event.head_commit.message, 'chore: ensure version files are updated to')"
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
     permissions:
@@ -109,9 +109,9 @@ jobs:
           echo "Checking version files..."
           grep -q "$NEW_VERSION" src/py_dem_bones/__version__.py || { echo "Version not updated in __version__.py"; exit 1; }
 
-          # Commit any changes to version files
+          # Commit any changes to version files with [skip ci] to avoid triggering other workflows
           git add src/py_dem_bones/__version__.py docs/conf.py
-          git commit -m "chore: ensure version files are updated to $NEW_VERSION" || echo "No changes to commit"
+          git commit -m "chore: ensure version files are updated to $NEW_VERSION [skip ci]" || echo "No changes to commit"
 
           # Push changes
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ on:
       - '.flake8'
       - '.pylintrc'
       - 'renovate.json'
+      - 'src/py_dem_bones/__version__.py'  # Ignore version file updates to avoid duplicate builds
   release:
     types: [published]
   pull_request:
@@ -48,6 +49,7 @@ on:
       - '.flake8'
       - '.pylintrc'
       - 'renovate.json'
+      - 'src/py_dem_bones/__version__.py'  # Ignore version file updates to avoid duplicate builds
   workflow_dispatch:
     inputs:
       fast-mode:


### PR DESCRIPTION
## Problem

When a version update occurs, multiple workflows are triggered, causing duplicate builds and unnecessary resource usage. This happens because:

1. The bumpversion.yml workflow creates a commit with the message "chore: ensure version files are updated to X.Y.Z"
2. This commit triggers other workflows like release.yml
3. These workflows may also update version files, creating a loop of triggers

## Solution

1. Added [skip ci] to the version update commit message in bumpversion.yml to prevent triggering other workflows
2. Added src/py_dem_bones/__version__.py to the paths-ignore list in release.yml to prevent triggering builds on version file updates
3. Updated the if condition in bumpversion.yml to ignore commits that start with "chore: ensure version files are updated to"

These changes ensure that version updates only trigger the necessary workflows once, avoiding duplicate builds and resource waste.