### PR TITLE
Fix CI workflow trigger issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Build and Release
 
 on:
+  # Only trigger on tag push, not on branch push
+  # This prevents duplicate builds when merging to main
+  # The bumpversion.yml workflow will create tags that trigger this workflow
   push:
     tags:
       - 'v*'
       - '[0-9]+.[0-9]+.[0-9]+*'
-    branches: [ main ]
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## Problem

When merging to the main branch, two workflows are triggered simultaneously:
- `bumpversion.yml` (needed)
- `release.yml` (not needed when merging to main)

This causes duplicate builds and unnecessary resource consumption.

## Solution

Modified the `.github/workflows/release.yml` file:
- Removed the push trigger for the main branch
- Kept the tag trigger to ensure that builds and releases are properly triggered when bumpversion creates a tag
- Added comments explaining the reason for the change

## Changes

- Removed `branches: [main]` from the release.yml trigger conditions
- Added comments explaining the workflow trigger logic

## Testing

After merging this PR, when new commits are merged to the main branch:
1. Only the `bumpversion.yml` workflow will be triggered
2. `bumpversion.yml` will automatically create a tag
3. When the tag is created, the `release.yml` workflow will be triggered for building and publishing